### PR TITLE
package "sklearn" is deprecated on pypi

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,7 +15,7 @@ Requires Python 3 (tested with `3.6.1`). The remaining dependencies can then be 
 
 You first need to preprocess any input data into the format expected by the model:
 
-        $ python preprocess.py --input <path to input dataset> --output <path to output dataset> --vocab <path to vocab file>
+        $ python preprocess.py --input <path to input directory> --output <path to output directory> --vocab <path to vocab file>
 
 where
 `<path to input directory>` points to a directory containing an input dataset (described below),

--- a/preprocess.py
+++ b/preprocess.py
@@ -42,7 +42,7 @@ def main(args):
         vocab = [w.strip() for w in f.readlines()]
     vocab_to_id = dict(zip(vocab, range(len(vocab))))
 
-    if not os.path.exists(args.output):
+    if not os.path.isdir(args.output):
         os.mkdir(args.output)
 
     labels = {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ Keras==2.0.4
 nltk==3.2.4
 numpy==1.12.1
 scikit-learn==0.18.1
-sklearn==0.0
 tensorflow==1.1.0

--- a/train.py
+++ b/train.py
@@ -108,7 +108,7 @@ def train(model, dataset, params):
 
 
 def main(args):
-    if not os.path.exists(args.model):
+    if not os.path.isdir(args.model):
         os.mkdir(args.model)
 
     with open(os.path.join(args.model, 'params.json'), 'w') as f:


### PR DESCRIPTION
removed 'sklearn' from requirements.txt as it's deprecated.
(btw: scikit-learn is still there, so sklear was redundant)

See:
https://pypi.python.org/pypi/sklearn/0.0