### PR TITLE
Sample data for eval

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -36,6 +36,7 @@ def evaluate_retrieval(model, dataset, params, session):
     if sampling:
         validation_size = dataset._get_collection_size('validation')
         training_size = dataset._get_collection_size('training')
+        # setup stratified sample between training and validation data sets
         sample_size = round(params.eval_max_sample*validation_size/(training_size+validation_size))
     else:
         sample_size = None
@@ -47,6 +48,7 @@ def evaluate_retrieval(model, dataset, params, session):
     )
     if sampling:
         validation_labels = validation_labels[dataset.sample_indexes]
+        # setup stratified sample between training and validation data sets
         sample_size = round(params.eval_max_sample*training_size/(training_size+validation_size))
     training_vectors = m.vectors(
         model,

--- a/model/data.py
+++ b/model/data.py
@@ -58,6 +58,7 @@ class Dataset(object):
             assert sample_size < collection_size, "Only samples smaller than available data are provided for."
             sample_indexes = np.random.choice(collection_size, sample_size, replace=False)
             sample_indexes.sort()
+            self.sample_indexes = sample_indexes
             sample_indexes = iter(sample_indexes)
             next_index = next(sample_indexes)
         while True:

--- a/model/data.py
+++ b/model/data.py
@@ -6,6 +6,7 @@ import itertools
 import numpy as np
 import keras.preprocessing.sequence as pp
 import tensorflow as tf
+from itertools import count
 
 seed = 42
 random.seed(seed)
@@ -31,28 +32,55 @@ class Dataset(object):
         self.path = path
         files = glob.glob(path + '/*.csv')
         self.collections = {file_name(file): file for file in files}
+        self.collection_sizes = {}
 
-    def rows(self, collection_name, num_epochs=None):
+    def _get_collection_size(self, collection):
+        size = self.collection_sizes.get(collection, None)
+        if size is not None:
+            return size
+        file = self.collections.get(collection, None)
+        if file is None:
+            raise ValueError("Collection %s not present!"%collection)
+        with open(file, 'r', newline='') as f:
+            r = csv.reader(f)
+            size = sum(1 for _ in r)
+        self.collection_sizes[collection] = size
+        return size
+
+    def rows(self, collection_name, num_epochs=None, sample_size=None):
         if collection_name not in self.collections:
             raise ValueError(
                 'Collection not found: {}'.format(collection_name)
             )
         epoch = 0
+        if sample_size is not None:
+            collection_size = self._get_collection_size(collection_name)
+            assert sample_size < collection_size, "Only samples smaller than available data are provided for."
+            sample_indexes = np.random.choice(collection_size, sample_size, replace=False)
+            sample_indexes.sort()
+            sample_indexes = iter(sample_indexes)
+            next_index = next(sample_indexes)
         while True:
             with open(self.collections[collection_name], 'r', newline='') as f:
                 r = csv.reader(f)
-                for row in r:
-                    yield row
+                if sample_size is None:
+                    for row in r:
+                        yield row
+                else:
+                    for row,index in zip(r, count()):
+                        if index == next_index:
+                            yield row
+                            next_index = next(sample_indexes) # NOTE: will raise StopIteration when indexes exhausted
             epoch += 1
             if num_epochs and (epoch >= num_epochs):
                 raise StopIteration
 
-    def _batch_iter(self, collection_name, batch_size, num_epochs):
-        gen = [self.rows(collection_name, num_epochs)] * batch_size
+    def _batch_iter(self, collection_name, batch_size, num_epochs, sample_size):
+        gen = [self.rows(collection_name, num_epochs, sample_size)] * batch_size
         return itertools.zip_longest(fillvalue=None, *gen)
 
-    def batches(self, collection_name, batch_size, num_epochs=None):
-        for batch in self._batch_iter(collection_name, batch_size, num_epochs):
+    def batches(self, collection_name, batch_size, num_epochs=None, sample_size=None):
+        for batch in self._batch_iter(collection_name, batch_size, num_epochs, sample_size):
             data = [format_row(row) for row in batch if row]
             y, x, seq_lengths = zip(*data)
             x = pp.pad_sequences(x, padding='post')

--- a/model/evaluate.py
+++ b/model/evaluate.py
@@ -1,7 +1,6 @@
 import numpy as np
 import sklearn.metrics.pairwise as pw
 
-import datetime
 def closest_docs_by_index(corpus_vectors, query_vectors, n_docs):
     docs = []
     sim = pw.cosine_similarity(corpus_vectors, query_vectors)

--- a/model/evaluate.py
+++ b/model/evaluate.py
@@ -1,7 +1,7 @@
 import numpy as np
 import sklearn.metrics.pairwise as pw
 
-
+import datetime
 def closest_docs_by_index(corpus_vectors, query_vectors, n_docs):
     docs = []
     sim = pw.cosine_similarity(corpus_vectors, query_vectors)

--- a/train.py
+++ b/train.py
@@ -81,11 +81,12 @@ def train(model, dataset, params):
                     ),
                     session
                 )
-                training_sample = dataset.sample_indexes
+                if params.eval_max_sample is not None:
+                    training_sample = dataset.sample_indexes
                 val = e.evaluate(
                     training_vectors,
                     validation_vectors,
-                    training_labels[training_sample],
+                    training_labels if params.eval_max_sample is None else training_labels[training_sample],
                     validation_labels
                 )[0]
                 print('validation: {:.3f} (best: {:.3f})'.format(

--- a/train.py
+++ b/train.py
@@ -81,10 +81,11 @@ def train(model, dataset, params):
                     ),
                     session
                 )
+                training_sample = dataset.sample_indexes
                 val = e.evaluate(
                     training_vectors,
                     validation_vectors,
-                    training_labels,
+                    training_labels[training_sample],
                     validation_labels
                 )[0]
                 print('validation: {:.3f} (best: {:.3f})'.format(

--- a/train.py
+++ b/train.py
@@ -1,4 +1,4 @@
-;import os
+import os
 import argparse
 import json
 import numpy as np

--- a/train.py
+++ b/train.py
@@ -1,4 +1,4 @@
-import os
+;import os
 import argparse
 import json
 import numpy as np
@@ -59,7 +59,7 @@ def train(model, dataset, params):
             losses.append(loss)
 
             if step % params.log_every == 0:
-                print('{}: {:.6f}'.format(step, loss))
+                print('{}: {:.6f}'.format(step, loss), flush=True)
 
             if step and (step % params.save_every) == 0:
                 validation_vectors = m.vectors(
@@ -90,11 +90,11 @@ def train(model, dataset, params):
                 print('validation: {:.3f} (best: {:.3f})'.format(
                     val,
                     best_val or 0.0
-                ))
+                ), flush=True)
 
                 if val > best_val:
                     best_val = val
-                    print('saving: {}'.format(model_dir))
+                    print('saving: {}'.format(model_dir), flush=True)
                     saver.save(session, model_dir, global_step=step)
 
                 summary, = session.run([summaries], feed_dict={

--- a/train.py
+++ b/train.py
@@ -76,7 +76,8 @@ def train(model, dataset, params):
                     dataset.batches(
                         'training',
                         params.batch_size,
-                        num_epochs=1
+                        num_epochs=1,
+                        sample_size=params.eval_max_sample
                     ),
                     session
                 )
@@ -147,6 +148,8 @@ def parse_args():
                         help='print loss after this many steps')
     parser.add_argument('--save-every', type=int, default=500,
                         help='print loss after this many steps')
+    parser.add_argument('--eval-max-sample', type=int, default=None,
+                        help='max training data sample size when evaluating')
     return parser.parse_args()
 
 


### PR DESCRIPTION
Provides a cli parameter --eval-max-sample wich restricts the number of (training) data points to be used during evaluation. If set, these are randomly sampled from the training data each evaluation. This can be used to prevent memory issues with evaluation when a large data set is used.